### PR TITLE
CVE-2020-1938 aka GhostCat - update Tomcat

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
 ### Changed
-* [DOCKER-123] Parametrize more variables in tomcat access valve: maxDays and rotatable
+
+* [DOCKER-313] Updated Tomcat to 7.0.103 / 8.5.53 
+* [DOCKER-297] Base JDK-8 ubuntu images on Bionic (18.04 LTS)
+* [DOCKER-295] Make `relaxedQueryChars` and `relaxedPathChars` configurable
+* [DOCKER-291] Updated Tomcat 8.5 to 8.5.49
+* [DOCKER-123] Parametrize more variables in tomcat access valve: `maxDays` and `rotatable`

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Apache Tomcat is an open source web server and servlet container, by the Apache 
 
 ## Supported tags
 
-* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.49-jdk-11u3-bionic`, `8.5-jdk-11u3-bionic`, `8-jdk-11u3-bionic`, `8.5.49-bionic`, `8.5-bionic`, `8-bionic`
-* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.94-jdk-8u212-bionic`, `7.0-jdk-8u212-bionic`, `7-jdk-8u212-bionic`, `7.0.94-bionic`, `7.0-bionic`, `7-bionic`
-* `alfresco-4.2-ubuntu`, `7.0.94-jdk-7u211-trusty`, `7.0-jdk-7u211-trusty`, `7-jdk-7u211-trusty`
-* `alfresco-4.2-centos`, `7.0.94-jdk-7u221-centos-7`, `7.0-jdk-7u221-centos-7`, `7-jdk-7u221-centos-7`
+* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.53-jdk-11u3-bionic`, `8.5-jdk-11u3-bionic`, `8-jdk-11u3-bionic`, `8.5.53-bionic`, `8.5-bionic`, `8-bionic`
+* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.103-jdk-8u212-bionic`, `7.0-jdk-8u212-bionic`, `7-jdk-8u212-bionic`, `7.0.103-bionic`, `7.0-bionic`, `7-bionic`
+* `alfresco-4.2-ubuntu`, `7.0.103-jdk-7u211-trusty`, `7.0-jdk-7u211-trusty`, `7-jdk-7u211-trusty`
+* `alfresco-4.2-centos`, `7.0.103-jdk-7u221-centos-7`, `7.0-jdk-7u221-centos-7`, `7-jdk-7u221-centos-7`
 
 ## Environment variables
 

--- a/tomcat-7.0/jdk-7-centos-7.gradle
+++ b/tomcat-7.0/jdk-7-centos-7.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev  : 94,
+                    rev  : 103,
                     canonical: true
             ]
     ]

--- a/tomcat-7.0/jdk-7-trusty.gradle
+++ b/tomcat-7.0/jdk-7-trusty.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev: 94,
+                    rev: 103,
                     canonical: true
             ]
     ]

--- a/tomcat-7.0/jdk-8-bionic.gradle
+++ b/tomcat-7.0/jdk-8-bionic.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev: 94,
+                    rev: 103,
                     canonical: true
             ]
     ]

--- a/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
+++ b/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 8,
                     minor: 5,
-                    rev: 49,
+                    rev: 53,
                     canonical: true
             ]
     ]


### PR DESCRIPTION
Update Tomcat:

- 7.0.94 -> 7.0.103
- 8.5.49 -> 8.5.53

This update addresses CVE-2020-1938 (GhostCat)