### PR TITLE
Cleaning up gradle build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
     jcenter()
 }
 
-String[] calcTags (Project project) {
+String[] calcTags(Project project) {
     def tomcat = project.ext.tomcat
     def java = project.ext.java
     def os = project.ext.os
@@ -24,7 +24,7 @@ String[] calcTags (Project project) {
     if (java.version.update != null)
         javaVersion += "u${java.version.update}"
 
-    if(os.name == null) os.name="${os.vendor}-${os.version}"
+    if (os.name == null) os.name = "${os.vendor}-${os.version}"
 
     tags << "${version.major}.${version.minor}.${version.rev}-${javaVersion}-${os.name}"
 
@@ -45,7 +45,7 @@ String[] calcTags (Project project) {
     return tags.unique()
 }
 
-String getDockerBaseImage (Project p) {
+String getDockerBaseImage(Project p) {
     String javaFlavor = p.java.flavor == 'jre' ? 'server-jre' : p.java.flavor
     String javaPart = "${javaFlavor}-${p.java.version.major}"
     if (p.java.version.update)
@@ -59,8 +59,8 @@ String getDockerBaseImage (Project p) {
 
 task printTags {
     doFirst {
-        project.subprojects.collect().reverse().findAll{ it.name.startsWith("tomcat-") }.each{
-            println "* ${calcTags(it).collect{"`${it}`"}.join(', ')}"
+        project.subprojects.collect().reverse().findAll { it.name.startsWith("tomcat-") }.each {
+            println "* ${calcTags(it).collect { "`${it}`" }.join(', ')}"
         }
     }
 }
@@ -106,11 +106,11 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
 
     buildDockerImage {
         buildArgs = [
-                'TOMCAT_MAJOR' : "${project.tomcat.version.major}",
-                'TOMCAT_MINOR' : "${project.tomcat.version.minor}",
+                'TOMCAT_MAJOR'   : "${project.tomcat.version.major}",
+                'TOMCAT_MINOR'   : "${project.tomcat.version.minor}",
                 'TOMCAT_REVISION': "${project.tomcat.version.rev}",
 
-                'BASE_IMAGE': getDockerBaseImage(project)
+                'BASE_IMAGE'     : getDockerBaseImage(project)
         ]
 
         if (project.hasProperty('extraBuildArgs'))
@@ -120,7 +120,6 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
             println buildArgs
         }
     }
-
 
 
     configurations {
@@ -140,7 +139,9 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
 
     dockerCompose {
         projectName = "tomcat-${project.name}"
-        useComposeFiles = ["${project.parent.project('integration-tests').projectDir}/src/main/compose/docker-compose.yml"]
+        useComposeFiles = [
+                "${project.parent.project('integration-tests').projectDir}/src/main/compose/docker-compose.yml"
+        ]
         captureContainersOutput = false
 
         // Uncomment for quick iterations when developing integration tests
@@ -170,14 +171,13 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
         doFirst {
             dockerCompose.exposeAsSystemProperties(test)
 
-            if("${project.java.version.major}"=='11' && "${project.os.vendor}"=='ubuntu')
+            if ("${project.java.version.major}" == '11' && "${project.os.vendor}" == 'ubuntu')
                 systemProperty 'test.java.version', '11'
             else
                 systemProperty 'test.java.version', "1.${project.java.version.major}"
             systemProperty 'test.java.flavor', project.java.flavor
         }
     }
-
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,11 +123,11 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
 
 
     configurations {
-        war
+        integrationTestWar
     }
 
     dependencies {
-        war project(path: ':integration-tests:servlet-info', configuration: 'wars')
+        integrationTestWar project(path: ':integration-tests:servlet-info', configuration: 'wars')
     }
 
     docker {
@@ -148,7 +148,7 @@ configure(subprojects.findAll { it.name.startsWith("tomcat-") }) {
         // stopContainers = false
 
         environment.put 'COMPOSE_TOMCAT_TCP_8080', '8080'
-        environment.put 'WAR_PATH', project.configurations.war.singleFile.absolutePath
+        environment.put 'WAR_PATH', configurations.integrationTestWar.singleFile.absolutePath
 
         // start & stop docker-compose when running tests
         isRequiredBy(project.tasks.test)

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
-    compile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
-    compile group: 'junit', name: 'junit', version: '4.12'
+    implementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    implementation group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
+    implementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/integration-tests/servlet-info/build.gradle
+++ b/integration-tests/servlet-info/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext {
+        // can't upgrade to Spring Boot 2 as long as we need to support Java 7
         springBootVersion = '1.5.11.RELEASE'
     }
     repositories {
@@ -39,19 +40,19 @@ configurations {
 }
 
 dependencies {
-    compile('org.springframework.boot:spring-boot-starter-web')
+    implementation('org.springframework.boot:spring-boot-starter-web')
 
     // Required for Tomcat 7.0 support
-    compile('javax.el:javax.el-api:3.0.0')
+    implementation('javax.el:javax.el-api:3.0.0')
 
-    runtime('org.springframework.boot:spring-boot-devtools')
+    runtimeOnly('org.springframework.boot:spring-boot-devtools')
 
     providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
-    testCompile('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 artifacts {
-    wars war.archivePath
+    wars war.archiveFile
 }
 
 


### PR DESCRIPTION
There is one build-warning remaining:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.1.1/userguide/command_line_interface.html#sec:command_line_warnings
```

This is caused by the Spring Boot 1 (!!) gradle plugin

Spring Boot 1 (SB1) is end-of-life, but SB2 does not support Java 7. That means as long as we're building Tomcat images with JDK-7, we'll be stuck with this warning and we won't be able to move to Gradle 7.0 (in the future)