### PR TITLE
Update Tomcat to 7.0.106 / 8.5.59

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+* [2020-10-28] [PR #14](https://github.com/xenit-eu/docker-tomcat/pull/14) Updated Tomcat to 7.0.106 / 8.5.59
 * [2020-10-28] [PR #13](https://github.com/xenit-eu/docker-tomcat/pull/13) Updated JDK to jdk-11.0.9 and jdk-8u272 and for CentOS to jdk-7u261
 
 ## 2020-04

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Apache Tomcat is an open source web server and servlet container, by the Apache 
 
 ## Supported tags
 
-* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.54-jdk-11u9-bionic`, `8.5-jdk-11u9-bionic`, `8-jdk-11u9-bionic`, `8.5.54-bionic`, `8.5-bionic`, `8-bionic`
-* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.103-jdk-8u272-bionic`, `7.0-jdk-8u272-bionic`, `7-jdk-8u272-bionic`, `7.0.103-bionic`, `7.0-bionic`, `7-bionic`
-* `alfresco-4.2-ubuntu`, `7.0.103-jdk-7u211-trusty`, `7.0-jdk-7u211-trusty`, `7-jdk-7u211-trusty`
-* `alfresco-4.2-centos`, `7.0.103-jdk-7u261-centos-7`, `7.0-jdk-7u261-centos-7`, `7-jdk-7u261-centos-7`
+* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.59-jdk-11u9-bionic`, `8.5-jdk-11u9-bionic`, `8-jdk-11u9-bionic`, `8.5.59-bionic`, `8.5-bionic`, `8-bionic`
+* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.106-jdk-8u272-bionic`, `7.0-jdk-8u272-bionic`, `7-jdk-8u272-bionic`, `7.0.106-bionic`, `7.0-bionic`, `7-bionic`
+* `alfresco-4.2-ubuntu`, `7.0.106-jdk-7u211-trusty`, `7.0-jdk-7u211-trusty`, `7-jdk-7u211-trusty`
+* `alfresco-4.2-centos`, `7.0.106-jdk-7u261-centos-7`, `7.0-jdk-7u261-centos-7`, `7-jdk-7u261-centos-7`
 
 ## Environment variables
 

--- a/tomcat-7.0/jdk-7-centos-7.gradle
+++ b/tomcat-7.0/jdk-7-centos-7.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev  : 103,
+                    rev  : 106,
                     canonical: true
             ]
     ]

--- a/tomcat-7.0/jdk-7-trusty.gradle
+++ b/tomcat-7.0/jdk-7-trusty.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev: 103,
+                    rev: 106,
                     canonical: true
             ]
     ]

--- a/tomcat-7.0/jdk-8-bionic.gradle
+++ b/tomcat-7.0/jdk-8-bionic.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 7,
                     minor: 0,
-                    rev: 103,
+                    rev: 106,
                     canonical: true
             ]
     ]

--- a/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
+++ b/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 8,
                     minor: 5,
-                    rev: 54,
+                    rev: 59,
                     canonical: true
             ]
     ]


### PR DESCRIPTION
Hello @tgeens ,

This PR updates Tomcat to the current versions
7.0 to 7.0.106 (2020-09-20)
8.5 to 8.5.59 (2020-10-06)

Feel free to decline when you don't want to update the Tomcat server.

This PR contains also the changes for PR #13 

Kind regards,
Koen