### PR TITLE
Update to jdk-11.0.9.1 and jdk-8u275

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,36 +1,23 @@
-# Changelog
+# docker-tomcat - CHANGELOG
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 2020-11
-
-### Changed
-
-* [2020-11-14] [PR #15](https://github.com/xenit-eu/docker-tomcat/pull/15) Updated JDK to jdk-11.0.9.1 and jdk-8u275
-
+* [2020-11-14] [PR #15](https://github.com/xenit-eu/docker-tomcat/pull/15) Update JDK to jdk-11.0.9.1 and jdk-8u275
 
 ## 2020-10
-
-### Changed
-
-* [2020-10-28] [PR #14](https://github.com/xenit-eu/docker-tomcat/pull/14) Updated Tomcat to 7.0.106 / 8.5.59
-* [2020-10-28] [PR #13](https://github.com/xenit-eu/docker-tomcat/pull/13) Updated JDK to jdk-11.0.9 and jdk-8u272 and for CentOS to jdk-7u261
+* [2020-10-28] [PR #14](https://github.com/xenit-eu/docker-tomcat/pull/14) Update Tomcat to 7.0.106 / 8.5.59
+* [2020-10-28] [PR #13](https://github.com/xenit-eu/docker-tomcat/pull/13) Update JDK to jdk-11.0.9 and jdk-8u272 and for CentOS to jdk-7u261
 
 ## 2020-04
-
-### Changed
-
-* [2020-04-18] [PR #10](https://github.com/xenit-eu/docker-tomcat/pull/10) Updated JDK to [jdk-11.0.7](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk11_0_7) and [jdk-8u252](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk8u252)
-* [2020-04-18] [PR #9](https://github.com/xenit-eu/docker-tomcat/pull/9) Updated Tomcat 8.5 to [8.5.54](http://tomcat.apache.org/tomcat-8.5-doc/changelog.html#Tomcat_8.5.54_(markt))
+* [2020-04-18] [PR #10](https://github.com/xenit-eu/docker-tomcat/pull/10) Update JDK to [jdk-11.0.7](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk11_0_7) and [jdk-8u252](https://adoptopenjdk.net/release_notes.html?jvmVariant=hotspot#jdk8u252)
+* [2020-04-18] [PR #9](https://github.com/xenit-eu/docker-tomcat/pull/9) Update Tomcat 8.5 to [8.5.54](http://tomcat.apache.org/tomcat-8.5-doc/changelog.html#Tomcat_8.5.54_(markt))
 
 ## 2020-03
-
-### Changed
-
-* [DOCKER-313] [PR #6](https://github.com/xenit-eu/docker-tomcat/pull/6) Updated Tomcat to 7.0.103 / 8.5.53 
+* [DOCKER-313] [PR #6](https://github.com/xenit-eu/docker-tomcat/pull/6) Update Tomcat to 7.0.103 / 8.5.53 
 * [DOCKER-297] [PR #4](https://github.com/xenit-eu/docker-tomcat/pull/4) Base JDK-8 ubuntu images on Bionic (18.04 LTS)
 * [DOCKER-295] [PR #3](https://github.com/xenit-eu/docker-tomcat/pull/3) Make `relaxedQueryChars` and `relaxedPathChars` configurable
-* [DOCKER-291] [PR #2](https://github.com/xenit-eu/docker-tomcat/pull/2) Updated Tomcat 8.5 to 8.5.49
+* [DOCKER-291] [PR #2](https://github.com/xenit-eu/docker-tomcat/pull/2) Update Tomcat 8.5 to 8.5.49
 * [DOCKER-123] [PR #1](https://github.com/xenit-eu/docker-tomcat/pull/1) Parametrize more variables in tomcat access valve: `maxDays` and `rotatable`

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## 2020-11
+
+### Changed
+
+* [2020-11-14] [PR #15](https://github.com/xenit-eu/docker-tomcat/pull/15) Updated JDK to jdk-11.0.9.1 and jdk-8u275
+
+
 ## 2020-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Apache Tomcat is an open source web server and servlet container, by the Apache 
 
 ## Supported tags
 
-* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.59-jdk-11u9-bionic`, `8.5-jdk-11u9-bionic`, `8-jdk-11u9-bionic`, `8.5.59-bionic`, `8.5-bionic`, `8-bionic`
-* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.106-jdk-8u272-bionic`, `7.0-jdk-8u272-bionic`, `7-jdk-8u272-bionic`, `7.0.106-bionic`, `7.0-bionic`, `7-bionic`
+* `alfresco-6.2-ubuntu`, `alfresco-6.1-ubuntu`, `alfresco-6.0-ubuntu`, `8.5.59-jdk-11u9.1-bionic`, `8.5-jdk-11u9.1-bionic`, `8-jdk-11u9.1-bionic`, `8.5.59-bionic`, `8.5-bionic`, `8-bionic`
+* `alfresco-5.2-ubuntu`, `alfresco-5.1-ubuntu`, `alfresco-5.0-ubuntu`, `7.0.106-jdk-8u275-bionic`, `7.0-jdk-8u275-bionic`, `7-jdk-8u275-bionic`, `7.0.106-bionic`, `7.0-bionic`, `7-bionic`
 * `alfresco-4.2-ubuntu`, `7.0.106-jdk-7u211-trusty`, `7.0-jdk-7u211-trusty`, `7-jdk-7u211-trusty`
 * `alfresco-4.2-centos`, `7.0.106-jdk-7u261-centos-7`, `7.0-jdk-7u261-centos-7`, `7-jdk-7u261-centos-7`
 
@@ -59,7 +59,7 @@ tomcat:<version>[-<java>[-<os>]]
 ```
 
 * **version**: the Tomcat version
-* **java**: the Java distribution and version, for example `jdk-8` or `jdk-8u272-bionic`
+* **java**: the Java distribution and version, for example `jdk-8` or `jdk-8u275-bionic`
 * **os**: the Operating System, for example `bionic` or `centos-7`
 
 ### Tomcat versions

--- a/tomcat-7.0/jdk-8-bionic.gradle
+++ b/tomcat-7.0/jdk-8-bionic.gradle
@@ -11,7 +11,7 @@ ext {
             flavor : 'jdk',
             version: [
                     major: 8,
-                    update: 272
+                    update: 275
             ],
             canonical: true
 

--- a/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
+++ b/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
@@ -11,7 +11,7 @@ ext {
             flavor : 'jdk',
             version: [
                     major: 11,
-                    update: 9
+                    update: 9.1
             ],
             canonical: true
     ]


### PR DESCRIPTION
Hello @tgeens ,

I updated the openjdk dependency to current version 2020-11.

Merge this pull request after merging [PR #19](https://github.com/xenit-eu/docker-openjdk/pull/19) in xenit-eu/docker-openjdk.

To propagate the openjdk updates to the Alfresco images, trigger community (travis) and enterprise (jenkins) builds of
- xenit-eu/docker-alfresco
- xenit-eu/docker-solr
- xenit-eu/docker-share
- Alfresco Digital Workspace image (enterprise only)

Kind regards,
Koen