### PR TITLE
DOCKER-359 update libxslt rpm link

### DIFF
--- a/src/main/docker/Dockerfile.centos
+++ b/src/main/docker/Dockerfile.centos
@@ -22,7 +22,7 @@ ENV GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 
 ENV TOMCAT_PORT=8080
 
-ARG RPM_LIBXSLT=http://mirror.centos.org/centos/7/os/x86_64/Packages/libxslt-1.1.28-5.el7.x86_64.rpm
+ARG RPM_LIBXSLT=http://mirror.centos.org/centos/7/os/x86_64/Packages/libxslt-1.1.28-6.el7.x86_64.rpm
 ARG RPM_XMLSTARLET=http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/x/xmlstarlet-1.6.1-1.el7.x86_64.rpm
 
 # copy init file


### PR DESCRIPTION
Jira ticket: https://xenitsupport.jira.com/browse/DOCKER-359

Issue: libxslt rpm is no longer available at old url.
Suggested solution: replace with qualifier bumped version (1.1.28-5 into 1.1.28-6)