### PR TITLE
DOCKER-366 update java8 image to 275

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+* [2021-02-22] [PR #23](https://github.com/xenit-eu/docker-tomcat/pull/23) Updated Java8 to jdk-8u275-b01
 * [2021-02-01] [PR #20](https://github.com/xenit-eu/docker-tomcat/pull/20) Updated JDK to jdk-11.0.10
 
 ## 2020-12

--- a/tomcat-7.0/jdk-8-bionic.gradle
+++ b/tomcat-7.0/jdk-8-bionic.gradle
@@ -11,7 +11,7 @@ ext {
             flavor : 'jdk',
             version: [
                     major: 8,
-                    update: 272
+                    update: 275
             ],
             canonical: true
 


### PR DESCRIPTION
The tomcat image did not yet use the u275 image of docker-openjdk, resulting in exceptions for bugs that were fixed in that update.