### PR TITLE
XS-65 update tomcat micro to version patched against cve-2022-22965

### DIFF
--- a/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
+++ b/tomcat-8.5/jdk-11-ubuntu-18.04.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 8,
                     minor: 5,
-                    rev: 59,
+                    rev: 78,
                     canonical: true
             ]
     ]

--- a/tomcat-9/jdk-11-ubuntu-20.04.gradle
+++ b/tomcat-9/jdk-11-ubuntu-20.04.gradle
@@ -3,7 +3,7 @@ ext {
             version: [
                     major: 9,
                     minor: 0,
-                    rev: 58,
+                    rev: 62,
                     canonical: true
             ]
     ]


### PR DESCRIPTION
Apache Tomcat received an update that disables  `WebappClassLoaderBase.getResources()` which should prevent exploitation of 
CVE-2022-22965.

See https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#status , 
https://spring.io/blog/2022/04/01/spring-framework-rce-mitigation-alternative , 
https://tomcat.apache.org/tomcat-8.5-doc/changelog.html 
and https://tomcat.apache.org/tomcat-9.0-doc/changelog.html